### PR TITLE
Recommendation to Retain MiniCPM-V-4-int4 Model Due to Its Low VRAM Usage

### DIFF
--- a/nodes_legacy.py
+++ b/nodes_legacy.py
@@ -26,7 +26,7 @@ class MiniCPM_VQA:
             "required": {
                 "text": ("STRING", {"default": "", "multiline": True}),
                 "model": (
-                    ["MiniCPM-V-4_5-int4", "MiniCPM-V-4_5"],
+                    ["MiniCPM-V-4_5-int4", "MiniCPM-V-4_5", "MiniCPM-V-4-int4", "MiniCPM-V-4"],
                     {"default": "MiniCPM-V-4_5-int4"},
                 ),
                 "keep_model_loaded": ("BOOLEAN", {"default": False}),

--- a/nodes_polished.py
+++ b/nodes_polished.py
@@ -26,7 +26,7 @@ class MiniCPM_VQA_Polished:
             "required": {
                 "text": ("STRING", {"default": "", "multiline": True}),
                 "model": (
-                    ["MiniCPM-V-4_5-int4", "MiniCPM-V-4_5"],
+                    ["MiniCPM-V-4_5-int4", "MiniCPM-V-4_5", "MiniCPM-V-4-int4", "MiniCPM-V-4"],
                     {"default": "MiniCPM-V-4_5-int4"},
                 ),
                 "keep_model_loaded": ("BOOLEAN", {"default": False}),


### PR DESCRIPTION
The MiniCPM-V-4-int4 model has a small memory footprint, making it very friendly for graphics cards with limited VRAM. Therefore, it is recommended to retain the MiniCPM-V-4-int4 model.

